### PR TITLE
Merge 'develop' into 'master'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # git-cc
 
-Simple bridge between base ClearCase or UCM and Git. Uses python 2.7.
+Simple bridge between base ClearCase or UCM and Git.
 
 ## Fork License disclaimer
 
@@ -8,6 +8,20 @@ This fork of [git-cc](https://github.com/charleso/git-cc) implements fixes for a
 more reliable usage of python encoding, making git-cc functioning in return (for me!).
 It is licensed under the GNU GENERAL PUBLIC LICENSE - please refer to [LICENSE](https://github.com/kendegemaro/git-cc_br_esw2/blob/master/LICENSE) for
 more details.
+
+## Python Software environment
+
+Use this software with a python 2.7.18 Anaconda/Conda environment. To make sure that nothing breaks with an exception, install these packages:
+- bosch-ca v. 1.0
+- ca-certificates v. 2022.10.11
+- certifi v. 2020.6.20
+- pip v. 19.3.1
+- setuptools v. 44.0.0
+- sqlite v. 3.30.1
+- vc v. 9
+- vs2008_runtime v. 9.00.307...
+- wheel v. 0.37.1
+- winvertstore v. 0.2
 
 The following rest of the README is the original text from [git-cc](https://github.com/charleso/git-cc).
 

--- a/git_cc/common.py
+++ b/git_cc/common.py
@@ -49,14 +49,14 @@ def get_users_module(path):
 
 CFG_CC = 'clearcase'
 CC_DIR = None
-ENCODING = "utf_8"
+ENCODING = "cp1252"
 if hasattr(sys.stdin, 'encoding'):
     ENCODING = sys.stdin.encoding
 if ENCODING is None:
     import locale
     locale_name, ENCODING = locale.getdefaultlocale()
 if ENCODING is None:
-    ENCODING = "ISO8859-1"
+    ENCODING = "cp1252"
 DEBUG = False
 
 def fail(string):

--- a/git_cc/rebase.py
+++ b/git_cc/rebase.py
@@ -29,6 +29,8 @@ cache = getCache()
 
 def main(stash=False, dry_run=False, lshistory=False, load=None):
     validateCC()
+    reload(sys)
+    sys.setdefaultencoding('cp1252')
     if not (stash or dry_run or lshistory):
         checkPristine()
 
@@ -195,7 +197,7 @@ class Group:
         except:
           debug("miscoded comment")
         with open("./.git/COMMIT_EDITMSG", "wb") as commitmsgfile:
-          commitmsgfile.write(comment.encode(ENCODING))
+          commitmsgfile.write(comment)
           commitmsgfile.close()
         
         try:


### PR DESCRIPTION
Set cp1252 (Windows) as default encoding to prevent exceptions